### PR TITLE
chore: Update pycryptodome dependency to version 3.20.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -355,4 +355,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1f36691397da0b7d6460ca6e9b92779861df3609c346a93383702c1424e9d79e"
+content-hash = "1fed6c01b5cf39ab8f5d178ee9ced78265ff51e661273569dbaa5da7ff69826d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = "^3.9"
 binance-connector = "^3.5.1"
 python-dotenv = "^1.0.0"
 mypy-extensions = "^1.0.0"
+pycryptodome = "^3.20.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Signed-off-by: Brian of London (home imac) <brian@v4v.app>
